### PR TITLE
Export PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,4 +20,5 @@ fi
 echo "-----> Installing whois package to ${BUILD_DIR}/vendor/whois/usr/bin/whois"
 mkdir -p $BUILD_DIR/vendor/whois
 dpkg -x $CACHE_DIR/$PACKAGE $BUILD_DIR/vendor/whois
-PATH="$BUILD_DIR/vendor/whois/usr/bin:$PATH"
+
+echo "export PATH=\$HOME/vendor/whois/usr/bin:\$PATH" >> $BUILD_DIR/.profile.d/whois_buildpack_paths.sh


### PR DESCRIPTION
Fix for https://github.com/thisismyrobot/heroku-buildpack-whois/issues/2
Export `PATH` in order to be able to call programme without direct path lookups.
